### PR TITLE
feat: força HTTPS en enllaç LMS

### DIFF
--- a/src/Controller/LmsController.php
+++ b/src/Controller/LmsController.php
@@ -44,6 +44,7 @@ class LmsController extends AbstractController{
         $appFirma = $lmsAuthService->createSignature($cip, $dni);
 
         $url = $this->generateUrl(route: "athenea_lms_form_lms", referenceType: UrlGeneratorInterface::ABSOLUTE_URL);
+        $url = str_replace('http://', 'https://', $url);
         return $this->render('@AtheneaLaMevaSalut/auto_form.html.twig', [
             'url' => $url,
             'CIP' => $cip,


### PR DESCRIPTION
Modifica la URL generada pel formulari LMS per assegurar que sempre utilitza HTTPS en comptes de HTTP. Aquest canvi és necessari per complir amb els requisits de seguretat del sistema LMS i garantir una connexió xifrada en tot moment.